### PR TITLE
Use XDS xAPI forwarding

### DIFF
--- a/src/config/endpoints.js
+++ b/src/config/endpoints.js
@@ -31,6 +31,8 @@ export const moreLikeThisUrl = `${backendHost}${elasticApi}more-like-this/`;
 export const saveSearchUrl = `${backendHost}${api}saved-filters`;
 export const saveSearchOwnedUrl = `${backendHost}${api}saved-filters/owned`;
 
+// Forward Statements
+export const statementsUrl = `${backendHost}${api}statements`;
 
 //Notifications
 export const allNotification = `${backendHost}/inbox/notifications/api/all_list/`;

--- a/src/utils/xapi/xAPIMapper.js
+++ b/src/utils/xapi/xAPIMapper.js
@@ -1,27 +1,12 @@
-import { endpoint, key, secret } from '@/config/xAPIConfig';
-import XAPI from "@xapi/xapi";
-
-let xapiInstance = null;
+import { axiosInstance } from '../../config/axiosConfig.js';
+import { statementsUrl } from '../../config/endpoints';
 
 class XAPIMapper {
-
-  constructor() {
-    const auth = XAPI.toBasicAuth(key, secret);
-
-    if (!xapiInstance) { xapiInstance = this; }
-    if (endpoint) {
-      this.xapiInstance = new XAPI({
-        endpoint: endpoint,
-        auth: auth
-      });
-    }
-
-    return xapiInstance;
-  }
-
   sendStatement = ({ statement }) => {
-    return this.xapiInstance?.sendStatement({ statement }).catch((err) => console.error(err));
-  }
+    return axiosInstance
+      .post(statementsUrl, [statement])
+      .catch((err) => console.error(err));
+  };
 }
 
-export default (new XAPIMapper);
+export default new XAPIMapper();


### PR DESCRIPTION
This PR modifies the xAPI facilities in xds-ui to use an xAPI-forwarding endpoint on the XDS server. In this way xAPI credentials are not exposed in the browser.

See corresponding backend PR here: https://github.com/OpenLXP/openlxp-xds/pull/87